### PR TITLE
Allow specifying iOS SDK for portability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-PROGS = fileproviderctl_internal haxx login launchd
-CC ?= clang
+PROGS := fileproviderctl_internal haxx login launchd
+CC    ?= clang
 STRIP ?= strip
-CFLAGS += -Os -isysroot $(shell xcrun -sdk iphoneos --show-sdk-path) -miphoneos-version-min=14.0 -arch arm64
+
+TARGET_SYSROOT ?= $(shell xcrun -sdk iphoneos --show-sdk-path)
+
+CFLAGS  += -Os -isysroot $(TARGET_SYSROOT) -miphoneos-version-min=14.0 -arch arm64
 LDLFAGS += -lSystem
 
 all: $(PROGS)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Note: requires macOS + existing jailbreak
 
 1. Ensure you have [ldid](https://github.com/ProcursusTeam/ldid) from Procursus Team.
 2. Modify haxx.c to include your own code (if you need it).
-3. Run `make` to build
+3. Run `make` to build. If you're not on macOS, specify `TARGET_SYSROOT`
 4. On the device, Copy `/System/Library/PrivateFrameworks/CoreAnalytics.framework/Support/analyticsd` to `/System/Library/PrivateFrameworks/CoreAnalytics.framework/Support/analyticsd.back`
 5. Then replace `/System/Library/PrivateFrameworks/CoreAnalytics.framework/Support/analyticsd` with `/usr/bin/fileproviderctl`
 6. Create the `/private/var/haxx` directory, mode should be 0777


### PR DESCRIPTION
This PR further extends portability by allowing users to specify the iOS SDK with `TARGET_SYSROOT` in the event of `xcrun` not being present.